### PR TITLE
Moves svg to files

### DIFF
--- a/images/calendar.svg
+++ b/images/calendar.svg
@@ -1,0 +1,16 @@
+<svg
+  class="text-grey w-3 h-3 mr-2"
+  viewBox="0 0 20 20"
+  version="1.1"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+>
+  <g id="Page-1" stroke="none" stroke-width="1" fill-rule="evenodd">
+    <g id="icon-shape">
+      <path
+        d="M1,3.99508929 C1,2.8932319 1.8926228,2 2.99508929,2 L17.0049107,2 C18.1067681,2 19,2.8926228 19,3.99508929 L19,18.0049107 C19,19.1067681 18.1073772,20 17.0049107,20 L2.99508929,20 C1.8932319,20 1,19.1073772 1,18.0049107 L1,3.99508929 Z M3,6 L17,6 L17,18 L3,18 L3,6 Z M5,0 L7,0 L7,2 L5,2 L5,0 Z M13,0 L15,0 L15,2 L13,2 L13,0 Z M5,9 L7,9 L7,11 L5,11 L5,9 Z M5,13 L7,13 L7,15 L5,15 L5,13 Z M9,9 L11,9 L11,11 L9,11 L9,9 Z M9,13 L11,13 L11,15 L9,15 L9,13 Z M13,9 L15,9 L15,11 L13,11 L13,9 Z M13,13 L15,13 L15,15 L13,15 L13,13 Z"
+        id="Combined-Shape"
+      ></path>
+    </g>
+  </g>
+</svg>

--- a/images/location.svg
+++ b/images/location.svg
@@ -1,0 +1,15 @@
+<svg
+  viewBox="0 0 20 20"
+  version="1.1"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+>
+  <g id="Page-1" stroke="none" stroke-width="1" fill-rule="evenodd">
+    <g id="icon-shape">
+      <path
+        d="M10,20 C10,20 17,10.8659932 17,7 C17,3.13400675 13.8659932,0 10,0 C6.13400675,0 3,3.13400675 3,7 C3,10.8659932 10,20 10,20 Z M10,9 C11.1045695,9 12,8.1045695 12,7 C12,5.8954305 11.1045695,5 10,5 C8.8954305,5 8,5.8954305 8,7 C8,8.1045695 8.8954305,9 10,9 Z"
+        id="Combined-Shape"
+      ></path>
+    </g>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -112,44 +112,18 @@
             <div class="mb-8">
               <div class="text-grey-darkest font-bold text-3xl mb-2">January Meetup: Pitch Night #1</div>
               <p class="text-md mb-2 text-grey-darkest flex items-center">
-                <svg
-                  class="text-grey w-3 h-3 mr-2"
-                  viewBox="0 0 20 20"
-                  version="1.1"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlns:xlink="http://www.w3.org/1999/xlink"
-                >
-                  <g id="Page-1" stroke="none" stroke-width="1" fill-rule="evenodd">
-                    <g id="icon-shape">
-                      <path
-                        d="M1,3.99508929 C1,2.8932319 1.8926228,2 2.99508929,2 L17.0049107,2 C18.1067681,2 19,2.8926228 19,3.99508929 L19,18.0049107 C19,19.1067681 18.1073772,20 17.0049107,20 L2.99508929,20 C1.8932319,20 1,19.1073772 1,18.0049107 L1,3.99508929 Z M3,6 L17,6 L17,18 L3,18 L3,6 Z M5,0 L7,0 L7,2 L5,2 L5,0 Z M13,0 L15,0 L15,2 L13,2 L13,0 Z M5,9 L7,9 L7,11 L5,11 L5,9 Z M5,13 L7,13 L7,15 L5,15 L5,13 Z M9,9 L11,9 L11,11 L9,11 L9,9 Z M9,13 L11,13 L11,15 L9,15 L9,13 Z M13,9 L15,9 L15,11 L13,11 L13,9 Z M13,13 L15,13 L15,15 L13,15 L13,13 Z"
-                        id="Combined-Shape"
-                      ></path>
-                    </g>
-                  </g>
-                </svg>
+                <div class="inline-flex h-3 w-3 mr-1 text-grey">
+                  <img src="images/calendar.svg" />
+                </div>
                 Thursday, Jan. 17th at 6:30 p.m.
               </p>
               <p class="text-md mb-2 text-grey-darkest flex items-center">
-                <svg
-                  class="text-grey w-3 h-3 mr-2"
-                  viewBox="0 0 20 20"
-                  version="1.1"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlns:xlink="http://www.w3.org/1999/xlink"
-                >
-                  <g id="Page-1" stroke="none" stroke-width="1" fill-rule="evenodd">
-                    <g id="icon-shape">
-                      <path
-                        d="M10,20 C10,20 17,10.8659932 17,7 C17,3.13400675 13.8659932,0 10,0 C6.13400675,0 3,3.13400675 3,7 C3,10.8659932 10,20 10,20 Z M10,9 C11.1045695,9 12,8.1045695 12,7 C12,5.8954305 11.1045695,5 10,5 C8.8954305,5 8,5.8954305 8,7 C8,8.1045695 8.8954305,9 10,9 Z"
-                        id="Combined-Shape"
-                      ></path>
-                    </g>
-                  </g>
-                </svg>
+                <div class="inline-flex h-3 w-3 mr-1 text-grey">
+                  <img src="images/location.svg" />
+                </div>
                 <a class="text-blue-dark no-underline" href="https://goo.gl/maps/RPSV3ioYeoq"> StarSpace46 </a>
               </p>
-              <p class="text-grey-darker text-base mb-2">
+              <p class="text-grey-darker text-base mb-2 mt-4">
                 We'll be kicking off our first round of 5-minute pitches this week. If you have a great idea for a
                 software business, we want to hear it.
               </p>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10626672/51076438-051c7a00-165e-11e9-8cde-2d41d61911e0.png)
It looks like Parcel strips out the `viewbox` property of inline svgs. This moves the svgs to a separate file so this should hopefully stop happening.